### PR TITLE
License incorrect in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "queue"
   ],
   "author": "Stephen Rugh <rugh@adobe.com>",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "apollo-link": "~1.2.13"
   },


### PR DESCRIPTION
The project is an Apache-2.0 licensed one but the package.json says ISC.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the license in package.json

## Related Issue

n/a

## Motivation and Context

Have project license and package.json match

## How Has This Been Tested?

n/a

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
