### PR TITLE
📦  Add npm publish workflows

### DIFF
--- a/.github/workflows/on-push-publish-to-npm.yml
+++ b/.github/workflows/on-push-publish-to-npm.yml
@@ -1,0 +1,19 @@
+name: on-push-publish-to-npm
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "package.json"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: yarn install
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}

--- a/.github/workflows/version-bump-publish.yml
+++ b/.github/workflows/version-bump-publish.yml
@@ -1,0 +1,36 @@
+name: version-bump-publish
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease"
+        required: true
+        default: "patch"
+      tag:
+        description: "The tag to publish to."
+        required: false
+        default: "latest"
+jobs:
+  checkout:
+    name: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: |
+          yarn install
+      - name: bump and pub
+        if: ${{ github.event.inputs.level != '' }}
+        run: |
+          yarn version --${{ github.event.inputs.level }}
+          git push
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}
+          access: "public"


### PR DESCRIPTION
## Description

Adds github action workflows to the project to automate publishing to npm.

## Related Issue

n/a

## Motivation and Context

We are moving to github action based publishing to npm and removing individual access from 

## How Has This Been Tested?

The github actions have been tested extensively and are in use by many other Adobe teams to publish to npm.

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
